### PR TITLE
feat: Enable bot operation in group chats

### DIFF
--- a/email2telegram.conf
+++ b/email2telegram.conf
@@ -9,6 +9,7 @@
 [telegram]
 #token = YOUR_TELEGRAM_BOT_TOKEN
 #user_id = YOUR_TELEGRAM_USER_ID_AS_INTEGER
+#chat_id = YOUR_TELEGRAM_CHAT_ID_AS_INTEGER
 
 [openai]
 #token = YOUR_OPEN_AI_TOKEN

--- a/main.go
+++ b/main.go
@@ -24,9 +24,26 @@ func main() {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
+	// Determine recipientID for Telegram bot
+	var recipientID int64
+	if cfg.TelegramChatID != 0 {
+		recipientID = cfg.TelegramChatID
+		log.Printf("Operating in group chat mode. Chat ID: %d", recipientID)
+		if cfg.TelegramUserId != 0 {
+			log.Printf("Note: Telegram UserID (%d) is also set in config, but ChatID (%d) takes precedence for bot operations.", cfg.TelegramUserId, cfg.TelegramChatID)
+		}
+	} else if cfg.TelegramUserId != 0 {
+		recipientID = cfg.TelegramUserId
+		log.Printf("Operating in direct user message mode. User ID: %d", recipientID)
+	} else {
+		// This case should ideally be caught by LoadConfig if the token is present,
+		// as LoadConfig validates that at least one ID is present if the token is.
+		log.Fatalf("Critical configuration error: Neither Telegram UserID nor ChatID is set after config load. Token presence: %t", cfg.TelegramToken != "")
+	}
+
 	// Telegram init
 
-	telegramBot, err := NewTelegramBot(cfg.TelegramToken, cfg.TelegramUserId)
+	telegramBot, err := NewTelegramBot(cfg.TelegramToken, recipientID)
 	if err != nil {
 		log.Fatalf("Failed to init Telegram bot: %v", err)
 	}


### PR DESCRIPTION
This commit introduces the capability for me to operate either in a direct message with you or within a group chat.

Key changes:

- Configuration (`config.go`, `email2telegram.conf`):
    - Added `chat_id` to the Telegram configuration.
    - I now require either `user_id` or `chat_id` to be set.
    - If both are set, `chat_id` takes precedence for determining the recipient for my communications.
    - The embedded configuration and the template `email2telegram.conf` file have been updated to include `chat_id`.

- Bot Logic (`telegram_bot.go`):
    - Renamed `allowedUserID` to `recipientID` in the `TelegramBot` struct and related functions to reflect its dual role.
    - Message sending functions now use `recipientID`.
    - The `handleUpdate` function now filters incoming messages based on `msg.Chat.ID == recipientID`. This allows me to correctly process messages in either a DM (where `recipientID` is your ID) or a group chat (where `recipientID` is the group's ID).
    - I will now accept input from any user within the target chat if in group mode.

- Initialization (`main.go`):
    - Logic added to determine the `recipientID` (either `user_id` or `chat_id` from config) at startup.
    - Appropriate logging has been added to indicate my operating mode.

This change allows you to deploy me in a group setting, expanding my usability.