### PR TITLE
feat: Automatically create '📥' topic when forum topics are enabled

### DIFF
--- a/telegram_bot.go
+++ b/telegram_bot.go
@@ -228,9 +228,25 @@ func (tb *TelegramBot) CheckTopicsEnabled(chatID int64) (bool, error) {
 	_, err := tb.api.MakeRequest("createForumTopic", params)
 	if err != nil {
 		if strings.Contains(err.Error(), "forum topics are not enabled") {
+			// Topics are explicitly not enabled.
 			return false, nil
 		}
+		// Some other unexpected error occurred during the check.
 		return false, fmt.Errorf("unexpected error while checking topics: %w", err)
+	}
+
+	// If we reach here, the initial check was successful (err == nil), meaning topics are enabled.
+	// Now, try to create the desired "📥" topic.
+	inboxTopicParams := tgbotapi.Params{
+		"chat_id": fmt.Sprint(chatID),
+		"name":    "📥",
+	}
+	_, createErr := tb.api.MakeRequest("createForumTopic", inboxTopicParams)
+	if createErr != nil {
+		log.Printf("Failed to create topic '📥' in chat ID %d: %v", chatID, createErr)
+		// Note: We still return true because the primary check for topic support succeeded.
+	} else {
+		log.Printf("Successfully created topic '📥' in chat ID %d", chatID)
 	}
 
 	return true, nil


### PR DESCRIPTION
I've modified the `CheckTopicsEnabled` function in `telegram_bot.go` to enhance its behavior upon confirming that a chat supports forum topics.

Previously, `CheckTopicsEnabled` would only verify if topics could be created. With this change, after a successful verification (by attempting to create a temporary topic), I now immediately attempt to create a persistent topic named "📥".

- If I create the "📥" topic successfully, a log message is recorded.
- If I fail to create the "📥" topic (e.g., it already exists, or I lack specific permissions despite being an admin), an error is logged. This failure does not prevent `CheckTopicsEnabled` from returning `true` if the initial topic support check was positive.

This ensures that if a chat is topic-enabled, an attempt is made to create the standard "📥" topic without requiring further manual intervention or separate logic in the message handler. The `handleUpdate` function continues to notify you if topics are not enabled at all.