### PR TITLE
Refactor: Move CheckTopicsEnabled to main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,20 @@ func main() {
 			// send a message to the user/group or handle it differently.
 			// For now, just logging.
 		}
+
+		// Check if topics are enabled for the chat
+		topicsEnabled, err := telegramBot.CheckTopicsEnabled(cfg.TelegramChatID)
+		if err != nil {
+			log.Printf("Error checking topics for chat ID %d: %v", cfg.TelegramChatID, err)
+		} else if !topicsEnabled {
+			notificationText := "В этой группе не включены темы. Пожалуйста, включите их для корректной работы."
+			notificationMsg := tgbotapi.NewMessage(cfg.TelegramChatID, notificationText)
+			if _, sendErr := telegramBot.api.Send(notificationMsg); sendErr != nil {
+				log.Printf("Error sending 'topics not enabled' notification to chat ID %d: %v", cfg.TelegramChatID, sendErr)
+			} else {
+				log.Printf("Sent 'topics not enabled' notification to chat ID %d.", cfg.TelegramChatID)
+			}
+		}
 	}
 
 	// OpenAI Client init


### PR DESCRIPTION
I moved the `CheckTopicsEnabled` call from `telegram_bot.go#handleUpdate` to `main.go`.

This change ensures that the topic check for group chats is performed once during bot initialization, immediately after the administrator rights check, rather than on every incoming message.

Changes:
- Removed `CheckTopicsEnabled` logic and the associated `topicCheckCompletedForChat` map from `telegram_bot.go`.
- Added `CheckTopicsEnabled` call in `main.go` within the group chat initialization block (`if cfg.TelegramChatID != 0`).
- Included error handling and a notification to you if topics are found to be disabled during the check in `main.go`.